### PR TITLE
Added extra ccd def for camera (Canon Ixus 240 HS)

### DIFF
--- a/ccd_defs.json
+++ b/ccd_defs.json
@@ -1,6 +1,7 @@
 {
   "Apple iPhone 5s": 8.46,
   "Asahi Optical Co.,Ltd.  PENTAX Optio330RS": 7.176,
+  "Canon Canon IXUS 240 HS": 6.17,
   "Canon Canon DIGITAL IXUS 400": 7.176,
   "Canon Canon DIGITAL IXUS 40": 5.76,
   "Canon Canon DIGITAL IXUS 430": 6.18,


### PR DESCRIPTION
http://snapsort.com/cameras/Canon-240-HS-specs/sensor-size-sane

JHead output:

Camera make  : Canon
Camera model : Canon IXUS 240 HS
